### PR TITLE
feat: add header indicating what epas version is implemented

### DIFF
--- a/lib/route-helpers.ts
+++ b/lib/route-helpers.ts
@@ -1,11 +1,15 @@
 import { v4 as uuidv4 } from 'uuid';
 import { initResponseBody, responseBody } from '../types/interfaces';
 
+const { dependencies } = require("../package.json");
+
+const epasVersion = dependencies["@eyevinn/player-analytics-specification"].replace("^", "");
 export const responseHeaders = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'Content-Type, Origin',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'X-EPAS-Version': epasVersion || "n/a",
 };
 
 export function generateResponseStatus({ path, method }: { path: string; method: string }): { statusCode: number; statusDescription: string } {

--- a/lib/route-helpers.ts
+++ b/lib/route-helpers.ts
@@ -1,9 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
 import { initResponseBody, responseBody } from '../types/interfaces';
 
-const { dependencies } = require("../package.json");
+const { version } = require("../node_modules/@eyevinn/player-analytics-specification/package.json");
 
-const epasVersion = dependencies["@eyevinn/player-analytics-specification"].replace("^", "");
+const epasVersion = version;
 export const responseHeaders = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',

--- a/spec/event_sink.spec.ts
+++ b/spec/event_sink.spec.ts
@@ -49,6 +49,9 @@ describe('event-sink module', () => {
       const response = await Lambda.handler(event);
       if (response.statusCode === 400) console.log(response.body);
       expect(response.statusCode).toEqual(200);
+      if (response.headers) {
+        expect(response.headers["X-EPAS-Version"]).not.toBeNull();
+      }
       if (payload.event === 'init') {
         expect(response.body).toContain('"sessionId":"123-214-234"');
         expect(response.body).toContain('"heartbeatInterval":5000');


### PR DESCRIPTION
This PR addresses #24 and adds a version header in all responses that indicates what EPAS version is implemented