### PR TITLE
feat: allow x-epas headers

### DIFF
--- a/lib/route-helpers.ts
+++ b/lib/route-helpers.ts
@@ -7,7 +7,7 @@ const epasVersion = version;
 export const responseHeaders = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'Content-Type, Origin',
+  'Access-Control-Allow-Headers': 'Content-Type, Origin, X-EPAS-Event, X-EPAS-Version',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'X-EPAS-Version': epasVersion || "n/a",
 };


### PR DESCRIPTION
This PR adds the headers `X-EPAS-Event` and `X-EPAS-Version` to the list of CORS header whitelist