### PR TITLE
Fix critical bugs and expand test coverage

### DIFF
--- a/lib/MemoryQueue.ts
+++ b/lib/MemoryQueue.ts
@@ -332,13 +332,23 @@ export default class MemoryQueue extends EventEmitter {
 
   async flush(): Promise<void> {
     this.logger.info(`Flushing memory queue with ${this.count} events`);
+    const maxWaitMs = 30000;
+    const startTime = Date.now();
 
     while (this.count > 0 && !this.isProcessing) {
+      if (Date.now() - startTime > maxWaitMs) {
+        this.logger.warn(`Flush timeout after ${maxWaitMs}ms. ${this.count} events remaining.`);
+        break;
+      }
       await this.processBatch();
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
 
     while (this.isProcessing) {
+      if (Date.now() - startTime > maxWaitMs) {
+        this.logger.warn(`Flush timeout waiting for processing. ${this.count} events remaining.`);
+        break;
+      }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
   }

--- a/lib/Sender.ts
+++ b/lib/Sender.ts
@@ -146,8 +146,8 @@ export default class Sender {
 
       return queueResponse;
     } catch (error) {
-      this.logger.error("Error getting queue adapter:", error);
-      return { message: error.message };
+      this.logger.error("Error sending to queue:", error instanceof Error ? error.message : String(error));
+      throw error;
     }
   }
 

--- a/services/fastify.ts
+++ b/services/fastify.ts
@@ -56,8 +56,13 @@ fastify.get("/health", (request, reply) => {
 });
 
 fastify.post("/", async (request, reply) => {
-  const body =
-    request.body instanceof Object ? request.body : JSON.parse(request.body);
+  let body;
+  try {
+    body = request.body instanceof Object ? request.body : JSON.parse(request.body);
+  } catch (parseError) {
+    reply.code(400).send({ error: "Invalid JSON in request body" });
+    return;
+  }
   const validatorTs = Date.now();
   const validEvent = validator.validateEvent(body);
   Logger.debug(`Time taken to validate event-> ${Date.now() - validatorTs}ms`);
@@ -98,13 +103,14 @@ fastify.post("/", async (request, reply) => {
       }
     } catch (error) {
       Logger.error("Sender timeout or error:", error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
       reply
         .status(502)
         .headers(generateResponseHeaders(request.headers.origin))
         .send({
           sessionId: body.sessionId || -1,
           message:
-            error.message === "Operation timed out"
+            errorMessage === "Operation timed out"
               ? "Request timeout"
               : "Queue service unavailable",
           valid: false,
@@ -129,10 +135,18 @@ fastify.options("/cmcd", (request, reply) => {
 fastify.post("/cmcd", async (request, reply) => {
   try {
     // Parse body
-    const body: CMCDv2RequestBody =
-      request.body instanceof Object
+    let body: CMCDv2RequestBody;
+    try {
+      body = request.body instanceof Object
         ? request.body
         : JSON.parse(request.body || "{}");
+    } catch (parseError) {
+      reply
+        .code(400)
+        .headers(generateResponseHeaders(request.headers.origin))
+        .send({ error: "Invalid JSON in request body" });
+      return;
+    }
 
     // Parse CMCDv2 data from body and headers
     const parsed = cmcdParser.parse(
@@ -198,7 +212,7 @@ fastify.post("/cmcd", async (request, reply) => {
           results.push({
             event: epasEvent.event,
             success: false,
-            error: error.message || "Failed to queue event",
+            error: (error instanceof Error ? error.message : String(error)) || "Failed to queue event",
           });
         }
       } else {
@@ -234,7 +248,7 @@ fastify.post("/cmcd", async (request, reply) => {
     reply
       .status(500)
       .headers(generateResponseHeaders(request.headers.origin))
-      .send(generateCMCDv2ErrorBody("Internal server error", [error.message]));
+      .send(generateCMCDv2ErrorBody("Internal server error", [error instanceof Error ? error.message : String(error)]));
   }
 });
 

--- a/services/lambda.ts
+++ b/services/lambda.ts
@@ -22,7 +22,16 @@ export const handler = async (event: ALBEvent): Promise<ALBResult> => {
     if (event.headers && event.headers['host']) {
       requestHost = event.headers['host'];
     }
-    const body = JSON.parse(event.body);
+    let body;
+    try {
+      body = JSON.parse(event.body);
+    } catch (parseError) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: "Invalid JSON in request body" }),
+        headers: { "Content-Type": "application/json" }
+      } as ALBResult;
+    }
     const validatorTs = Date.now();
     const validEvent = validator.validateEvent(body);
     Logger.debug(`Time taken to validate event-> ${Date.now() - validatorTs}ms`);
@@ -53,11 +62,12 @@ export const handler = async (event: ALBEvent): Promise<ALBResult> => {
         }
       } catch (error) {
         Logger.error('Sender timeout or error:', error);
+        const errorMessage = error instanceof Error ? error.message : String(error);
         response.statusCode = 502;
         response.statusDescription = 'Bad Gateway';
         response.body = JSON.stringify({
           sessionId: body.sessionId || -1,
-          message: error.message === 'Operation timed out' ? 'Request timeout' : 'Queue service unavailable',
+          message: errorMessage === 'Operation timed out' ? 'Request timeout' : 'Queue service unavailable',
           valid: false,
         });
       }
@@ -71,7 +81,7 @@ export const handler = async (event: ALBEvent): Promise<ALBResult> => {
       statusCode: 200,
       statusDescription: 'OK',
       headers: generateResponseHeaders(),
-      body: '{ status: "OK" }',
+      body: JSON.stringify({ status: "OK" }),
     };
     return response as ALBResult;
   }

--- a/spec/event_sink.spec.ts
+++ b/spec/event_sink.spec.ts
@@ -191,7 +191,7 @@ describe('event-sink module', () => {
         message: 'No queue type specified',
       });
     });
-    process.env.QUEUE_TYPE = undefined;
+    delete process.env.QUEUE_TYPE;
     const sqsResp = { MessageId: '12345678-4444-5555-6666-111122223333' };
     const event = request;
     event.path = '/';
@@ -199,9 +199,10 @@ describe('event-sink module', () => {
 
     sqsMock.on(SendMessageCommand).resolves(sqsResp);
     const response = await Lambda.handler(event);
+    expect(sqsMock.calls()).toHaveSize(0);
+    // When QUEUE_TYPE is not set, sendToActualQueue returns early with a message
     expect(response.statusCode).toEqual(200);
     expect(response.statusDescription).toEqual('OK');
-    expect(sqsMock.calls()).toHaveSize(0);
     expect(response.body).toContain('No queue type specified');
   });
 });

--- a/spec/fastify.spec.ts
+++ b/spec/fastify.spec.ts
@@ -1,19 +1,197 @@
+// Disable memory queue before any imports to ensure it's set during module initialization
+process.env.DISABLE_MEMORY_QUEUE = 'true';
+
 import { fastify } from '../services/fastify';
+import { valid_events, invalid_events } from './events/test_events';
+import { SqsQueueAdapter } from '@eyevinn/player-analytics-shared';
 
 describe('Fastify server', () => {
-  it('should validate allowed origin if CORS_ALLOWED_ORIGINS is defined', async () => {
-    process.env.CORS_ALLOWED_ORIGINS = 'https://test.domain.net, http://test.domain.net';
-    const response = await fastify.inject({
-      method: 'OPTIONS',
-      url: '/',
-      headers: {
-        'origin': 'https://test.domain.net'
+  let originalHeartbeatInterval: string | undefined;
+
+  beforeEach(() => {
+    originalHeartbeatInterval = process.env.HEARTBEAT_INTERVAL;
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.QUEUE_TYPE = 'SQS';
+    process.env.SQS_QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/1234/test-queue';
+    process.env.CORS_ALLOWED_ORIGINS = '';
+  });
+
+  afterEach(() => {
+    process.env.CORS_ALLOWED_ORIGINS = '';
+    if (originalHeartbeatInterval !== undefined) {
+      process.env.HEARTBEAT_INTERVAL = originalHeartbeatInterval;
+    } else {
+      delete process.env.HEARTBEAT_INTERVAL;
+    }
+  });
+
+  describe('OPTIONS / endpoint', () => {
+    it('should validate allowed origin if CORS_ALLOWED_ORIGINS is defined', async () => {
+      process.env.CORS_ALLOWED_ORIGINS = 'https://test.domain.net, http://test.domain.net';
+      const response = await fastify.inject({
+        method: 'OPTIONS',
+        url: '/',
+        headers: {
+          'origin': 'https://test.domain.net'
+        }
+      });
+      if (response.headers) {
+        expect(response.headers['access-control-allow-origin']).toEqual('https://test.domain.net');
+      }
+      process.env.CORS_ALLOWED_ORIGINS = '';
+    });
+
+    it('should return CORS headers for OPTIONS request', async () => {
+      const response = await fastify.inject({
+        method: 'OPTIONS',
+        url: '/',
+      });
+      expect(response.statusCode).toEqual(200);
+      expect(response.headers['access-control-allow-origin']).toEqual('*');
+      expect(response.headers['access-control-allow-methods']).toEqual('POST, OPTIONS');
+      expect(response.headers['access-control-allow-headers']).toContain('Content-Type');
+      const body = JSON.parse(response.body);
+      expect(body.status).toEqual('ok');
+    });
+  });
+
+  describe('POST / endpoint', () => {
+    beforeEach(() => {
+      spyOn(SqsQueueAdapter.prototype, 'pushToQueue').and.callFake(function () {
+        return Promise.resolve({
+          MessageId: '12345678-4444-5555-6666-111122223333',
+        });
+      });
+    });
+
+    it('should return 200 with sessionId for valid event', async () => {
+      const validEvent = valid_events[2]; // heartbeat event
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/',
+        payload: validEvent,
+      });
+      expect(response.statusCode).toEqual(200);
+      const body = JSON.parse(response.body);
+      expect(body.sessionId).toEqual('123-214-234');
+      expect(body.valid).toEqual(true);
+      expect(response.headers['x-epas-version']).toBeDefined();
+      expect(response.headers['content-type']).toContain('application/json');
+    });
+
+    it('should return 200 with sessionId and heartbeatInterval for init event', async () => {
+      const initEvent = valid_events[0]; // init event
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/',
+        payload: initEvent,
+      });
+      expect(response.statusCode).toEqual(200);
+      const body = JSON.parse(response.body);
+      expect(body.sessionId).toEqual('123-214-234');
+      expect(body.heartbeatInterval).toEqual(5000); // default numeric value when env var not set
+      expect(response.headers['x-epas-version']).toBeDefined();
+    });
+
+    it('should return 400 with error info for invalid event', async () => {
+      const invalidEvent = invalid_events[0]; // missing required fields
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/',
+        payload: invalidEvent,
+      });
+      expect(response.statusCode).toEqual(400);
+      const body = JSON.parse(response.body);
+      expect(body.sessionId).toEqual('123-214-234');
+      expect(body.message).toEqual('Invalid player event');
+      expect(body.valid).toEqual(false);
+    });
+
+    it('should return 400 for malformed JSON', async () => {
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/',
+        payload: 'this is not valid json {',
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+      expect(response.statusCode).toEqual(400);
+      // Fastify's built-in parser returns "Bad Request" before reaching our handler
+      expect(response.body).toContain('Bad Request');
+    });
+
+    it('should process all valid event types successfully', async () => {
+      for (const validEvent of valid_events) {
+        const response = await fastify.inject({
+          method: 'POST',
+          url: '/',
+          payload: validEvent,
+        });
+        expect(response.statusCode).toEqual(200);
+        const body = JSON.parse(response.body);
+        if (validEvent.event === 'init') {
+          expect(body.sessionId).toEqual('123-214-234');
+          expect(body.heartbeatInterval).toBeDefined();
+        } else {
+          expect(body.sessionId).toEqual('123-214-234');
+          expect(body.valid).toEqual(true);
+        }
       }
     });
-    if (response.headers) {
-      expect(response.headers['access-control-allow-origin']).toEqual('https://test.domain.net');
-    }
-    process.env.CORS_ALLOWED_ORIGINS = '';
-  });  
+  });
+
+  describe('GET /health endpoint', () => {
+    it('should return 200 with stats', async () => {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/health',
+      });
+      expect(response.statusCode).toEqual(200);
+      expect(response.headers['content-type']).toContain('application/json');
+      const body = JSON.parse(response.body);
+      expect(body.status).toEqual('ok');
+      expect(body.timestamp).toBeDefined();
+      expect(body.memoryQueue).toBeDefined();
+      expect(body.memoryQueue.enabled).toEqual(false); // disabled in tests
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should return 404 for POST to wrong path', async () => {
+      spyOn(SqsQueueAdapter.prototype, 'pushToQueue').and.callFake(function () {
+        return Promise.resolve({
+          MessageId: '12345678-4444-5555-6666-111122223333',
+        });
+      });
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/invalid',
+        payload: valid_events[0],
+      });
+      expect(response.statusCode).toEqual(404);
+      expect(response.body).toContain('Not Found');
+    });
+
+    it('should return 405 Method Not Allowed for GET to /', async () => {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/',
+      });
+      expect(response.statusCode).toEqual(405);
+      expect(response.body).toContain('Method Not Allowed');
+    });
+
+    it('should return CORS headers even for error responses', async () => {
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/',
+        payload: invalid_events[0],
+      });
+      expect(response.statusCode).toEqual(400);
+      expect(response.headers['access-control-allow-origin']).toEqual('*');
+      expect(response.headers['access-control-allow-methods']).toEqual('POST, OPTIONS');
+    });
+  });
 });
-  
+


### PR DESCRIPTION
## Summary
- Add JSON parse safety (try/catch) in Lambda and Fastify POST handlers
- Fix invalid JSON in Lambda OPTIONS response (JSON.stringify instead of string literal)
- Fix Sender to re-throw errors instead of silently returning error objects
- Add 30-second timeout to MemoryQueue flush() to prevent infinite loops
- Apply error instanceof Error pattern across all catch blocks
- Fix env var handling in tests (delete instead of setting to undefined)
- Add 10 new Fastify HTTP endpoint tests (POST/OPTIONS/GET/edge cases)

**Test results: 80 specs, 0 failures** (up from 70)

## Test plan
- [x] All 80 specs pass with `npm test`
- [ ] Verify malformed JSON handling with real HTTP requests
- [ ] Verify Sender error propagation works with SQS queue failures
- [ ] Verify MemoryQueue flush timeout behavior under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)