### PR TITLE
fix: cache AJV schema and return validation error details

### DIFF
--- a/benchmark-validator.ts
+++ b/benchmark-validator.ts
@@ -1,0 +1,68 @@
+/**
+ * Benchmark: AJV Validator performance
+ * Run from repo root: npx ts-node benchmark-validator.ts
+ *
+ * Measures validation throughput for the Validator class.
+ * Compare results between main (uncached) and the PR branch (cached).
+ */
+import Logger from './logging/logger';
+import { Validator } from './lib/Validator';
+
+// Suppress winston output during benchmark
+Logger.silent = true;
+
+const validEvents = [
+  { event: 'init', sessionId: 'bench-001', timestamp: Date.now(), playhead: -1, duration: -1 },
+  { event: 'playing', sessionId: 'bench-001', timestamp: Date.now(), playhead: 0, duration: 120 },
+  { event: 'heartbeat', sessionId: 'bench-001', timestamp: Date.now(), playhead: 10, duration: 120 },
+  { event: 'buffering', sessionId: 'bench-001', timestamp: Date.now(), playhead: 15, duration: 120 },
+  { event: 'metadata', sessionId: 'bench-001', timestamp: Date.now(), playhead: 0, duration: 120, payload: { live: false, contentTitle: 'Benchmark Video', deviceType: 'desktop' } },
+];
+
+const invalidEvents = [
+  { event: 'heartbeat', sessionId: 'bench-001', timestamp: Date.now() }, // missing playhead, duration
+  { event: 'unknown_event', sessionId: 'bench-001', timestamp: Date.now(), playhead: 0, duration: 0 },
+  {},
+];
+
+const ITERATIONS = 1000;
+
+function runBenchmark(label: string, iterations: number, events: any[]) {
+  const validator = new Validator(Logger);
+
+  // Warm up (1 call)
+  validator.validateEvent(events[0]);
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    for (const event of events) {
+      validator.validateEvent(event);
+    }
+  }
+  const elapsed = performance.now() - start;
+  const totalCalls = iterations * events.length;
+  const avgMs = elapsed / totalCalls;
+  const opsPerSec = Math.round(1000 / avgMs);
+
+  console.log(`${label}:`);
+  console.log(`  Total calls: ${totalCalls}`);
+  console.log(`  Total time:  ${elapsed.toFixed(1)}ms`);
+  console.log(`  Avg per call: ${avgMs.toFixed(3)}ms`);
+  console.log(`  Throughput:  ${opsPerSec.toLocaleString()} validations/sec`);
+  console.log();
+
+  return { totalCalls, elapsed, avgMs, opsPerSec };
+}
+
+console.log('=== AJV Validator Benchmark ===\n');
+
+const validResult = runBenchmark('Valid events', ITERATIONS, validEvents);
+const invalidResult = runBenchmark('Invalid events', ITERATIONS, invalidEvents);
+
+const mixedEvents = [...validEvents, ...invalidEvents];
+const mixedResult = runBenchmark('Mixed (valid + invalid)', ITERATIONS, mixedEvents);
+
+console.log('--- Summary ---');
+console.log(`Valid:   ${validResult.opsPerSec.toLocaleString()} ops/sec (${validResult.avgMs.toFixed(3)}ms/call)`);
+console.log(`Invalid: ${invalidResult.opsPerSec.toLocaleString()} ops/sec (${invalidResult.avgMs.toFixed(3)}ms/call)`);
+console.log(`Mixed:   ${mixedResult.opsPerSec.toLocaleString()} ops/sec (${mixedResult.avgMs.toFixed(3)}ms/call)`);

--- a/lib/Validator.ts
+++ b/lib/Validator.ts
@@ -1,39 +1,70 @@
-import { EventValidator } from '../types/interfaces';
+import { EventValidator, ValidationResult } from '../types/interfaces';
 import { schema } from '../resources/schema';
 import winston from 'winston';
-import Ajv from 'ajv';
+import Ajv, { ValidateFunction } from 'ajv';
 
 export class Validator implements EventValidator {
   logger: winston.Logger;
   eventSchema: object;
+  private compiledValidator: ValidateFunction | null;
 
   constructor(logger: winston.Logger) {
     this.logger = logger;
     this.eventSchema = schema;
+
+    // Compile schema ONCE at construction time
+    const ajv = new Ajv({ allowUnionTypes: true });
+    ajv.addSchema(this.eventSchema);
+    this.compiledValidator = ajv.getSchema('#/definitions/TPlayerAnalyticsEvent') || null;
+
+    if (!this.compiledValidator) {
+      this.logger.error('AJV failed in generating a validator for specified JSON schema');
+    }
   }
+
   /**
    * Method that validates a single event object
    * @param event the event object
+   * @returns ValidationResult with valid flag and optional error details
    */
-  validateEvent(event: Object): boolean {
+  validateEvent(event: Object | undefined | null): ValidationResult {
     if (!event) {
       this.logger.error('Event is undefined');
-      return false;
+      return {
+        valid: false,
+        errors: [{ field: '', message: 'Event is undefined' }],
+      };
     }
 
-    const ajv = new Ajv({ allowUnionTypes: true });
-    ajv.addSchema(this.eventSchema);
-    const validator = ajv.getSchema('#/definitions/TPlayerAnalyticsEvent');
-    if (validator) {
-      const valid = validator(event);
-      this.logger.debug(`Event: \n ${JSON.stringify(event)} is ${valid ? 'valid' : 'invalid'}`);
-      if (!valid) {
-        this.logger.debug(validator.errors);
-      }
-      return valid as boolean;
-    } else {
-      this.logger.error('AJV failed in generating a validator for specified JSON schema');
-      return false;
+    if (!this.compiledValidator) {
+      this.logger.error('No compiled validator available');
+      return {
+        valid: false,
+        errors: [{ field: '', message: 'Schema validator not available' }],
+      };
     }
+
+    const valid = this.compiledValidator(event);
+    this.logger.debug(`Event: \n ${JSON.stringify(event)} is ${valid ? 'valid' : 'invalid'}`);
+
+    if (!valid && this.compiledValidator.errors) {
+      this.logger.debug(this.compiledValidator.errors);
+      // Deduplicate errors (anyOf schemas produce duplicates per variant)
+      const seen = new Set<string>();
+      const errors = this.compiledValidator.errors
+        .map((err) => ({
+          field: err.instancePath || '/',
+          message: err.message || 'Unknown validation error',
+        }))
+        .filter((err) => {
+          const key = `${err.field}:${err.message}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+      return { valid: false, errors };
+    }
+
+    return { valid: valid as boolean };
   }
 }

--- a/lib/route-helpers.ts
+++ b/lib/route-helpers.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import {
   initResponseBody,
   responseBody,
+  ValidationError,
   CMCDv2ResponseBody,
   CMCDv2EventResult,
   CMCDv2ErrorResponse,
@@ -80,12 +81,17 @@ export function generateValidResponseBody(
  */
 export function generateInvalidResponseBody(
   event?: Record<string, any>,
+  errors?: ValidationError[],
 ): responseBody {
-  return {
+  const body: responseBody = {
     sessionId: event?.sessionId || -1,
     message: "Invalid player event",
     valid: false,
   };
+  if (errors && errors.length > 0) {
+    body.errors = errors;
+  }
+  return body;
 }
 
 export function generateInitResponseBody(

--- a/services/fastify.ts
+++ b/services/fastify.ts
@@ -59,10 +59,10 @@ fastify.post("/", async (request, reply) => {
   const body =
     request.body instanceof Object ? request.body : JSON.parse(request.body);
   const validatorTs = Date.now();
-  const validEvent = validator.validateEvent(body);
+  const validationResult = validator.validateEvent(body);
   Logger.debug(`Time taken to validate event-> ${Date.now() - validatorTs}ms`);
 
-  if (validEvent) {
+  if (validationResult.valid) {
     const senderTs = Date.now();
     try {
       const useMemoryQueue = process.env.DISABLE_MEMORY_QUEUE !== "true";
@@ -114,7 +114,7 @@ fastify.post("/", async (request, reply) => {
     reply
       .status(400)
       .headers(generateResponseHeaders(request.headers.origin))
-      .send(generateInvalidResponseBody(body));
+      .send(generateInvalidResponseBody(body, validationResult.errors));
   }
 });
 
@@ -183,9 +183,9 @@ fastify.post("/cmcd", async (request, reply) => {
     const useMemoryQueue = process.env.DISABLE_MEMORY_QUEUE !== "true";
 
     for (const epasEvent of epasEvents) {
-      const validEvent = validator.validateEvent(epasEvent);
+      const epasValidation = validator.validateEvent(epasEvent);
 
-      if (validEvent) {
+      if (epasValidation.valid) {
         try {
           if (useMemoryQueue) {
             await sender.send(epasEvent);
@@ -202,13 +202,16 @@ fastify.post("/cmcd", async (request, reply) => {
           });
         }
       } else {
+        const errorDetail = epasValidation.errors
+          ? epasValidation.errors.map((e) => `${e.field}: ${e.message}`).join('; ')
+          : 'Unknown validation error';
         Logger.debug(
           `Invalid EPAS event generated from CMCDv2: ${JSON.stringify(epasEvent)}`,
         );
         results.push({
           event: epasEvent.event,
           success: false,
-          error: "Generated EPAS event failed validation",
+          error: `EPAS validation failed: ${errorDetail}`,
         });
         warnings.push(`Event '${epasEvent.event}' failed EPAS validation`);
       }

--- a/services/lambda.ts
+++ b/services/lambda.ts
@@ -24,15 +24,15 @@ export const handler = async (event: ALBEvent): Promise<ALBResult> => {
     }
     const body = JSON.parse(event.body);
     const validatorTs = Date.now();
-    const validEvent = validator.validateEvent(body);
+    const validationResult = validator.validateEvent(body);
     Logger.debug(`Time taken to validate event-> ${Date.now() - validatorTs}ms`);
     const response = {
-      statusCode: validEvent ? 200 : 400,
-      statusDescription: validEvent ? 'OK' : 'Bad Request',
+      statusCode: validationResult.valid ? 200 : 400,
+      statusDescription: validationResult.valid ? 'OK' : 'Bad Request',
       headers: generateResponseHeaders(),
       body: '{}',
     };
-    if (validEvent) {
+    if (validationResult.valid) {
       body.host = requestHost;
       const senderTs = Date.now();
       try {
@@ -62,7 +62,7 @@ export const handler = async (event: ALBEvent): Promise<ALBResult> => {
         });
       }
     } else {
-      response.body = JSON.stringify(generateInvalidResponseBody(body));
+      response.body = JSON.stringify(generateInvalidResponseBody(body, validationResult.errors));
     }
     return response as ALBResult;
   }

--- a/spec/Validator.spec.ts
+++ b/spec/Validator.spec.ts
@@ -5,17 +5,62 @@ import { valid_events, invalid_events } from './events/test_events';
 const validator = new Validator(Logger);
 
 describe('JSONValidator', () => {
-  it('should return true if valid events are provided', async () => {
+  it('should return valid: true for valid events', async () => {
     for (const event of valid_events) {
-      const resp = validator.validateEvent(event);
-      expect(resp).toBe(true);
+      const result = validator.validateEvent(event);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toBeUndefined();
     }
   });
 
-  it('should return false if invalid events are provided', async () => {
+  it('should return valid: false with errors for invalid events', async () => {
     for (const event of invalid_events) {
-      const resp = validator.validateEvent(event);
-      expect(resp).toBe(false);
+      const result = validator.validateEvent(event);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.errors!.length).toBeGreaterThan(0);
     }
+  });
+
+  it('should return descriptive error details for missing fields', () => {
+    // Event missing playhead and duration
+    const badEvent = {
+      event: 'heartbeat',
+      sessionId: '123',
+      timestamp: 0,
+    };
+    const result = validator.validateEvent(badEvent);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+
+    // Should mention missing required properties
+    const errorMessages = result.errors!.map((e) => e.message).join(' ');
+    expect(errorMessages).toContain('required property');
+  });
+
+  it('should handle undefined event', () => {
+    const result = validator.validateEvent(undefined);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors![0].message).toBe('Event is undefined');
+  });
+
+  it('should handle empty object', () => {
+    const result = validator.validateEvent({});
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.length).toBeGreaterThan(0);
+  });
+
+  it('should reuse cached schema across calls (performance)', () => {
+    // Validate multiple events rapidly — proves caching works
+    const start = Date.now();
+    for (let i = 0; i < 100; i++) {
+      validator.validateEvent(valid_events[0]);
+    }
+    const elapsed = Date.now() - start;
+    // 100 validations should complete in under 100ms with caching
+    // (without caching, each AJV compile takes ~5-10ms = 500-1000ms)
+    expect(elapsed).toBeLessThan(100);
   });
 });

--- a/spec/event_sink.spec.ts
+++ b/spec/event_sink.spec.ts
@@ -113,9 +113,12 @@ describe('event-sink module', () => {
       const response = await Lambda.handler(event);
       expect(response.statusCode).toEqual(400);
       expect(response.statusDescription).toEqual('Bad Request');
-      expect(response.body).toEqual(
-        '{"sessionId":"123-214-234","message":"Invalid player event","valid":false}'
-      );
+      const body = JSON.parse(response.body!);
+      expect(body.sessionId).toEqual('123-214-234');
+      expect(body.message).toEqual('Invalid player event');
+      expect(body.valid).toBe(false);
+      expect(body.errors).toBeDefined();
+      expect(body.errors.length).toBeGreaterThan(0);
     }
   });
 
@@ -130,7 +133,12 @@ describe('event-sink module', () => {
     const response = await Lambda.handler(event);
     expect(response.statusCode).toEqual(400);
     expect(response.statusDescription).toEqual('Bad Request');
-    expect(response.body).toEqual('{"sessionId":-1,"message":"Invalid player event","valid":false}');
+    const body = JSON.parse(response.body!);
+    expect(body.sessionId).toEqual(-1);
+    expect(body.message).toEqual('Invalid player event');
+    expect(body.valid).toBe(false);
+    expect(body.errors).toBeDefined();
+    expect(body.errors.length).toBeGreaterThan(0);
   });
 
   it('should dismiss request if "path" != "/" ', async () => {

--- a/types/interfaces.ts
+++ b/types/interfaces.ts
@@ -9,6 +9,7 @@ export interface responseBody {
   sessionId: string;
   valid: boolean;
   message?: string;
+  errors?: ValidationError[];
   queueResponse?: any;
 }
 
@@ -19,10 +20,20 @@ export type validatorResponse = {
   body: responseBody;
 };
 
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors?: ValidationError[];
+}
+
 export interface EventValidator {
   logger: winston.Logger;
   eventSchema: any;
-  validateEvent(event: Object): boolean;
+  validateEvent(event: Object | undefined | null): ValidationResult;
 }
 
 // CMCDv2 response interfaces


### PR DESCRIPTION
## Summary
- **Cache AJV schema compilation** in constructor instead of creating new instances on every request — fixes the #1 performance bottleneck (#28)
- **Return validation error details** in 400 responses with field paths and messages from AJV (#19)
- Deduplicate AJV errors from anyOf schemas
- Widen `validateEvent()` signature to `Object | undefined | null` (no `as any` casts)

Closes #28
Closes #19

## Before/After

**Before:**
```json
{"sessionId":"123","message":"Invalid player event","valid":false}
```

**After:**
```json
{"sessionId":"123","message":"Invalid player event","valid":false,"errors":[{"field":"/","message":"must have required property 'duration'"},{"field":"/","message":"must match a schema in anyOf"}]}
```

## Benchmark Results

Ran 1,000 iterations x 8 event types, comparing main (new AJV per request) vs this PR (cached AJV):

| Metric | Before (main) | After (cached) | Improvement |
| --- | --- | --- | --- |
| Valid events | 158 ops/sec (6.34ms/call) | 263,950 ops/sec (0.004ms/call) | 1,670x faster |
| Invalid events | 157 ops/sec (6.37ms/call) | 153,808 ops/sec (0.007ms/call) | 980x faster |
| Mixed workload | 154 ops/sec (6.47ms/call) | 264,551 ops/sec (0.004ms/call) | 1,718x faster |

**Before:** Every request creates a new AJV instance and recompiles the entire EPAS schema (~6.4ms per validation).

**After:** Schema compiled once at startup, reused for all requests (~0.004ms per validation).

At 1,000 concurrent sessions with 5-second heartbeats, that's 200 validations/sec. Before: 1.27 seconds of CPU per second just on validation. After: 0.0008 seconds.

Benchmark script: `benchmark-validator.ts` in the repo root.

## Test plan
- [x] 74 specs passing, `tsc --noEmit` clean
- [x] Invalid events return deduplicated error details
- [x] Undefined/null/empty input handled with proper errors
- [x] Schema caching verified: 100 validations in <100ms
- [x] Lambda and Fastify routes pass errors to 400 responses
- [x] CMCDv2 route includes validation details in failure results

🤖 Generated with [Claude Code](https://claude.com/claude-code)