### PR TITLE
fix: add Vary: Origin header for dynamic CORS and document metadata pass-through

### DIFF
--- a/lib/route-helpers.ts
+++ b/lib/route-helpers.ts
@@ -28,10 +28,12 @@ export function generateResponseHeaders(origin?: string) {
       return {
         ...responseHeaders,
         "Access-Control-Allow-Origin": origin,
+        Vary: "Origin",
       };
     } else {
       return {
         ...responseHeaders,
+        Vary: "Origin",
       };
     }
   }

--- a/spec/Validator.spec.ts
+++ b/spec/Validator.spec.ts
@@ -18,4 +18,40 @@ describe('JSONValidator', () => {
       expect(resp).toBe(false);
     }
   });
+
+  it('should accept metadata events with custom string fields (additionalProperties)', () => {
+    const metadataWithCustomFields = {
+      event: 'metadata',
+      sessionId: 'test-session',
+      timestamp: 1000,
+      playhead: 0,
+      duration: 120,
+      payload: {
+        live: false,
+        contentTitle: 'Test Video',
+        customMetadataId: '42',       // custom string field
+        customCategory: 'sports',     // custom string field
+        isPromoted: true,             // custom boolean field
+      },
+    };
+    expect(validator.validateEvent(metadataWithCustomFields)).toBe(true);
+  });
+
+  it('should reject metadata events with integer custom fields (spec limitation)', () => {
+    const metadataWithIntegerField = {
+      event: 'metadata',
+      sessionId: 'test-session',
+      timestamp: 1000,
+      playhead: 0,
+      duration: 120,
+      payload: {
+        live: false,
+        contentTitle: 'Test Video',
+        customMetadataId: 42,         // integer — NOT allowed by EPAS v0.5.0 schema
+      },
+    };
+    // EPAS v0.5.0 additionalProperties only allows ["string", "boolean"]
+    // Integers must be sent as strings (e.g., "42") to pass validation
+    expect(validator.validateEvent(metadataWithIntegerField)).toBe(false);
+  });
 });

--- a/spec/event_sink.spec.ts
+++ b/spec/event_sink.spec.ts
@@ -41,6 +41,7 @@ describe('event-sink module', () => {
 
 
   it('can generate valid response headers', () => {
+    // Wildcard mode (no CORS_ALLOWED_ORIGINS) — no Vary header needed
     process.env.CORS_ALLOWED_ORIGINS = '';
     const responseHeaders = generateResponseHeaders();
     expect(responseHeaders['Content-Type']).toEqual('application/json');
@@ -48,14 +49,13 @@ describe('event-sink module', () => {
     expect(responseHeaders['Access-Control-Allow-Headers']).toEqual('Content-Type, Origin, X-EPAS-Event, X-EPAS-Version');
     expect(responseHeaders['Access-Control-Allow-Methods']).toEqual('POST, OPTIONS');
     expect(responseHeaders['X-EPAS-Version']).not.toBeNull();
+    expect(responseHeaders['Vary']).not.toBeDefined();
 
     const responseHeadersWithOrigin = generateResponseHeaders('https://example.com');
-    expect(responseHeadersWithOrigin['Content-Type']).toEqual('application/json');
     expect(responseHeadersWithOrigin['Access-Control-Allow-Origin']).toEqual('*');
-    expect(responseHeadersWithOrigin['Access-Control-Allow-Headers']).toEqual('Content-Type, Origin, X-EPAS-Event, X-EPAS-Version');
-    expect(responseHeadersWithOrigin['Access-Control-Allow-Methods']).toEqual('POST, OPTIONS');
-    expect(responseHeadersWithOrigin['X-EPAS-Version']).not.toBeNull();
+    expect(responseHeadersWithOrigin['Vary']).not.toBeDefined();
 
+    // Dynamic CORS — Vary: Origin must be present
     process.env.CORS_ALLOWED_ORIGINS = 'https://example.com, https://mydomain.com';
     const responseHeadersWithAllowedOrigin = generateResponseHeaders('https://mydomain.com');
     expect(responseHeadersWithAllowedOrigin['Content-Type']).toEqual('application/json');
@@ -63,13 +63,13 @@ describe('event-sink module', () => {
     expect(responseHeadersWithAllowedOrigin['Access-Control-Allow-Headers']).toEqual('Content-Type, Origin, X-EPAS-Event, X-EPAS-Version');
     expect(responseHeadersWithAllowedOrigin['Access-Control-Allow-Methods']).toEqual('POST, OPTIONS');
     expect(responseHeadersWithAllowedOrigin['X-EPAS-Version']).not.toBeNull();
+    expect(responseHeadersWithAllowedOrigin['Vary']).toEqual('Origin');
 
+    // Not-allowed origin — still needs Vary: Origin (CDN must know to vary)
     const responseHeadersWithNotAllowedOrigin = generateResponseHeaders('https://notallowed.com');
     expect(responseHeadersWithNotAllowedOrigin['Content-Type']).toEqual('application/json');
     expect(responseHeadersWithNotAllowedOrigin['Access-Control-Allow-Origin']).not.toBeDefined();
-    expect(responseHeadersWithNotAllowedOrigin['Access-Control-Allow-Headers']).toEqual('Content-Type, Origin, X-EPAS-Event, X-EPAS-Version');
-    expect(responseHeadersWithNotAllowedOrigin['Access-Control-Allow-Methods']).toEqual('POST, OPTIONS');
-    expect(responseHeadersWithNotAllowedOrigin['X-EPAS-Version']).not.toBeNull();
+    expect(responseHeadersWithNotAllowedOrigin['Vary']).toEqual('Origin');
     process.env.CORS_ALLOWED_ORIGINS = '';
   });
 

--- a/spec/fastify.spec.ts
+++ b/spec/fastify.spec.ts
@@ -12,6 +12,7 @@ describe('Fastify server', () => {
     });
     if (response.headers) {
       expect(response.headers['access-control-allow-origin']).toEqual('https://test.domain.net');
+      expect(response.headers['vary']).toEqual('Origin');
     }
     process.env.CORS_ALLOWED_ORIGINS = '';
   });  


### PR DESCRIPTION
## Summary
- **Add `Vary: Origin` header** when `CORS_ALLOWED_ORIGINS` is configured, preventing CDN/browser cache poisoning across origins (#30)
- **Document custom metadata pass-through** with tests proving EPAS v0.5.0 already accepts custom string/boolean fields (#48)
- Integer metadata fields must be sent as strings (spec limitation, not eventsink limitation)

Closes #30
Addresses #48

## CORS Vary Header Behavior

| Scenario | Access-Control-Allow-Origin | Vary |
| --- | --- | --- |
| Allowed origin | `http://localhost:1234` | `Origin` |
| Not-allowed origin | (not set) | `Origin` |
| No Origin / wildcard mode | `*` | (not set) |

When `CORS_ALLOWED_ORIGINS` is configured, the `Access-Control-Allow-Origin` header varies by request origin. Without `Vary: Origin`, CDNs may cache one origin's CORS response and serve it to a different origin — breaking CORS.

## Custom Metadata (Issue #48)

EPAS v0.5.0 schema already allows `additionalProperties` of type `string | boolean` in metadata payloads. Tests confirm:
- `customMetadataId: "42"` → passes validation
- `isPromoted: true` → passes validation
- `customMetadataId: 42` (integer) → rejected by schema

For integer custom fields: send as string (works today), or update the EPAS spec to allow integers.

## Test plan
- [x] 72 specs passing, `tsc --noEmit` clean
- [x] Vary: Origin present when CORS_ALLOWED_ORIGINS set and origin matches
- [x] Vary: Origin present when origin not allowed (CDN must vary)
- [x] No Vary header in wildcard mode
- [x] Custom string/boolean metadata passes validation
- [x] Integer metadata rejected (documented limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)